### PR TITLE
locking glob-stream on 5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "brfs": "^1.4.1",
     "duplexify": "^3.2.0",
-    "glob-stream": "^5.0.0",
+    "glob-stream": "~5.2.0",
     "graceful-fs": "^4.0.0",
     "gulp-sourcemaps": "^1.5.2",
     "is-valid-glob": "^0.3.0",


### PR DESCRIPTION
We have hit a issue on https://github.com/ipfs/js-ipfs-api/pull/169 because glob-stream 5.3.0 has a new version of micromatch which breaks js-ipfs-api. (please someone call the semver police 🚨 :P)

@dignifiedquire has locked 5.2.0 on js-ipfs-api, but to avoid having to cause more people pass through the debugging of this problem if they decide to use this module, I'm just going to make it more strict here too.
